### PR TITLE
Fix aliased table

### DIFF
--- a/src/Backup.php
+++ b/src/Backup.php
@@ -114,7 +114,7 @@ abstract class Backup
             throw new SkipTableException();
         }
 
-        if (!empty($table['sourceTable'])) {
+        if (!empty($table['bucket']['sourceBucket'])) {
             $this->logger->warning(sprintf('Skipping table %s (Data Catalog)', $table['id']));
             throw new SkipTableException();
         }
@@ -153,7 +153,7 @@ abstract class Backup
         $tables = $this->sapiClient->listTables(null, [
             'include' => 'columns,buckets,metadata,columnMetadata',
         ]);
-        $tables = array_filter($tables, fn($table) => empty($table['sourceTable']));
+        $tables = array_filter($tables, fn($table) => empty($table['bucket']['sourceBucket']));
 
         $this->putToStorage('tables.json', (string) json_encode($tables));
     }

--- a/tests/S3BackupTest.php
+++ b/tests/S3BackupTest.php
@@ -681,7 +681,7 @@ class S3BackupTest extends TestCase
         $fileOption->setTags(['tag1', 'tag2']);
 
         $this->sapiClient->uploadFile($file->getPathname(), $fileOption);
-
+        sleep(1);
         $backup = new S3Backup(
             $this->sapiClient,
             $this->s3Client,


### PR DESCRIPTION
Fixnutí migrace aliasů.. tím že jsme přidali přeskakování tabulek z data katalogu se začali přeskakovat i aliasované tabulky 

tabulky z data katalogu se dají poznat ještě tak že mají nadefinovaný `source_bucket`