### PR TITLE
Split tests by cloud platform (AWS/Azure/GCP matrix)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,5 @@
 name: GitHub Actions
 on: [ push ]
-concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
 env:
   # Name of the image in the ECR
   APP_IMAGE: php-kbc-project-backup
@@ -37,6 +36,9 @@ jobs:
     outputs:
       app_image_tag: ${{ steps.tag.outputs.app_image_tag }}
       is_semantic_tag: ${{ steps.tag.outputs.is_semantic_tag }}
+    concurrency: 
+      group: build-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       -
         name: Check out the repo
@@ -51,23 +53,79 @@ jobs:
       -
         name: Build image
         run: docker build -t $APP_IMAGE .
+
+  static-analysis:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency: 
+      group: static-analysis-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
       -
-        name: Run tests
-        run: docker run
-          -e TEST_AWS_STORAGE_API_URL
-          -e TEST_AWS_STORAGE_API_TOKEN
-          -e TEST_AWS_ACCESS_KEY_ID
-          -e TEST_AWS_SECRET_ACCESS_KEY
-          -e TEST_AWS_REGION
-          -e TEST_AWS_S3_BUCKET
-          -e TEST_AZURE_STORAGE_API_URL
-          -e TEST_AZURE_STORAGE_API_TOKEN
-          -e TEST_AZURE_ACCOUNT_NAME
-          -e TEST_AZURE_ACCOUNT_KEY
-          -e TEST_AZURE_CONTAINER_NAME
-          -e TEST_GCP_STORAGE_API_URL
-          -e TEST_GCP_STORAGE_API_TOKEN
-          -e TEST_GCP_BUCKET
-          -e TEST_GCP_SERVICE_ACCOUNT
-          ${{env.APP_IMAGE}}
-          composer ci
+        name: Run static analysis
+        run: docker run ${{env.APP_IMAGE}} composer static-analysis
+
+  test:
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    concurrency: 
+      group: test-${{ matrix.platform }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        platform: [aws, azure, gcp]
+      # Ensure that a failure in one platform doesn't stop other platforms from testing
+      fail-fast: false
+    env:
+      # AWS Credentials
+      TEST_AWS_ACCESS_KEY_ID: "AKIATDSWT524X5RNRXWF"
+      TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+      TEST_AWS_REGION: "us-east-1"
+      TEST_AWS_S3_BUCKET: "php-kbc-project-backup-s3filesbucket-1d2rc211smfc"
+      TEST_AWS_STORAGE_API_URL: "https://connection.keboola.com/"
+      TEST_AWS_STORAGE_API_TOKEN: "${{ secrets.TEST_AWS_STORAGE_API_TOKEN }}"
+
+      # Azure Credentials
+      TEST_AZURE_ACCOUNT_NAME: "projectmigration"
+      TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
+      TEST_AZURE_CONTAINER_NAME: "project-migration-test-container"
+      TEST_AZURE_STORAGE_API_URL: "https://connection.north-europe.azure.keboola.com/"
+      TEST_AZURE_STORAGE_API_TOKEN: "${{ secrets.TEST_AZURE_STORAGE_API_TOKEN }}"
+
+      # GCP Credentials
+      TEST_GCP_STORAGE_API_URL: "https://connection.europe-west3.gcp.keboola.com/"
+      TEST_GCP_STORAGE_API_TOKEN: "${{ secrets.TEST_GCP_STORAGE_API_TOKEN }}"
+      TEST_GCP_BUCKET: "ci-php-kbc-project-backup"
+      TEST_GCP_SERVICE_ACCOUNT: "${{ secrets.TEST_GCP_SERVICE_ACCOUNT }}"
+    steps:
+      -
+        name: Run ${{ matrix.platform }} tests
+        run: |
+          if [ "${{ matrix.platform }}" = "aws" ]; then
+            docker run \
+              -e TEST_AWS_STORAGE_API_URL \
+              -e TEST_AWS_STORAGE_API_TOKEN \
+              -e TEST_AWS_ACCESS_KEY_ID \
+              -e TEST_AWS_SECRET_ACCESS_KEY \
+              -e TEST_AWS_REGION \
+              -e TEST_AWS_S3_BUCKET \
+              ${{env.APP_IMAGE}} \
+              composer test-aws
+          elif [ "${{ matrix.platform }}" = "azure" ]; then
+            docker run \
+              -e TEST_AZURE_STORAGE_API_URL \
+              -e TEST_AZURE_STORAGE_API_TOKEN \
+              -e TEST_AZURE_ACCOUNT_NAME \
+              -e TEST_AZURE_ACCOUNT_KEY \
+              -e TEST_AZURE_CONTAINER_NAME \
+              ${{env.APP_IMAGE}} \
+              composer test-azure
+          else
+            docker run \
+              -e TEST_GCP_STORAGE_API_URL \
+              -e TEST_GCP_STORAGE_API_TOKEN \
+              -e TEST_GCP_BUCKET \
+              -e TEST_GCP_SERVICE_ACCOUNT \
+              ${{env.APP_IMAGE}} \
+              composer test-gcp
+          fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,28 +8,6 @@ env:
   DOCKERHUB_USER: "keboolabot"
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # AWS Credentials
-  TEST_AWS_ACCESS_KEY_ID: "AKIATDSWT524X5RNRXWF"
-  TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-  TEST_AWS_REGION: "us-east-1"
-  TEST_AWS_S3_BUCKET: "php-kbc-project-backup-s3filesbucket-1d2rc211smfc"
-  # https://connection.keboola.com/admin/projects/9016/dashboard
-  TEST_AWS_STORAGE_API_URL: "https://connection.keboola.com/"
-  TEST_AWS_STORAGE_API_TOKEN: "${{ secrets.TEST_AWS_STORAGE_API_TOKEN }}"
-
-  # Azure Credentials
-  TEST_AZURE_ACCOUNT_NAME: "projectmigration"
-  TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
-  TEST_AZURE_CONTAINER_NAME: "project-migration-test-container"
-  # https://connection.north-europe.azure.keboola.com/admin/projects/5837/dashboard
-  TEST_AZURE_STORAGE_API_URL: "https://connection.north-europe.azure.keboola.com/"
-  TEST_AZURE_STORAGE_API_TOKEN: "${{ secrets.TEST_AZURE_STORAGE_API_TOKEN }}"
-
-  # GCP Credentials
-  TEST_GCP_STORAGE_API_URL: "https://connection.europe-west3.gcp.keboola.com/"
-  TEST_GCP_STORAGE_API_TOKEN: "${{ secrets.TEST_GCP_STORAGE_API_TOKEN }}"
-  TEST_GCP_BUCKET: "ci-php-kbc-project-backup"
-  TEST_GCP_SERVICE_ACCOUNT: "${{ secrets.TEST_GCP_SERVICE_ACCOUNT }}"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -104,6 +82,7 @@ jobs:
       TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
       TEST_AWS_REGION: "us-east-1"
       TEST_AWS_S3_BUCKET: "php-kbc-project-backup-s3filesbucket-1d2rc211smfc"
+      # https://connection.keboola.com/ad\min/projects/9016/dashboard
       TEST_AWS_STORAGE_API_URL: "https://connection.keboola.com/"
       TEST_AWS_STORAGE_API_TOKEN: "${{ secrets.TEST_AWS_STORAGE_API_TOKEN }}"
 
@@ -111,6 +90,7 @@ jobs:
       TEST_AZURE_ACCOUNT_NAME: "projectmigration"
       TEST_AZURE_ACCOUNT_KEY: ${{ secrets.TEST_AZURE_ACCOUNT_KEY }}
       TEST_AZURE_CONTAINER_NAME: "project-migration-test-container"
+      # https://connection.north-europe.azure.keboola.com/admin/projects/5837/dashboard
       TEST_AZURE_STORAGE_API_URL: "https://connection.north-europe.azure.keboola.com/"
       TEST_AZURE_STORAGE_API_TOKEN: "${{ secrets.TEST_AZURE_STORAGE_API_TOKEN }}"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,6 +44,9 @@ jobs:
         name: Check out the repo
         uses: actions/checkout@v4
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Print Docker version
         run: docker -v
       -
@@ -51,8 +54,18 @@ jobs:
         if: env.DOCKERHUB_TOKEN
         run: docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
       -
-        name: Build image
-        run: docker build -t $APP_IMAGE .
+        name: Build and export
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: ${{ env.APP_IMAGE }}
+          outputs: type=docker,dest=/tmp/image.tar
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image
+          path: /tmp/image.tar
 
   static-analysis:
     needs: build
@@ -61,6 +74,15 @@ jobs:
       group: static-analysis-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image
+          path: /tmp
+      -
+        name: Load image
+        run: docker load --input /tmp/image.tar
       -
         name: Run static analysis
         run: docker run ${{env.APP_IMAGE}} composer static-analysis
@@ -98,6 +120,15 @@ jobs:
       TEST_GCP_BUCKET: "ci-php-kbc-project-backup"
       TEST_GCP_SERVICE_ACCOUNT: "${{ secrets.TEST_GCP_SERVICE_ACCOUNT }}"
     steps:
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image
+          path: /tmp
+      -
+        name: Load image
+        run: docker load --input /tmp/image.tar
       -
         name: Run ${{ matrix.platform }} tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 vendor
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -37,23 +37,17 @@
         }
     },
     "scripts": {
-        "phpunit": "phpunit",
         "phplint": "parallel-lint -j 10 --exclude vendor .",
         "phpcs": "phpcs -n --ignore=vendor --extensions=php .",
-        "phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",
         "phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",
-        "tests": [
-            "@phpunit"
-        ],
-        "build": [
+        "test-aws": "phpunit tests/S3BackupTest.php",
+        "test-azure": "phpunit tests/AbsBackupTest.php",
+        "test-gcp": "phpunit tests/GcsBackupTest.php",
+        "static-analysis": [
+            "@composer validate --no-check-publish --no-check-all",
             "@phplint",
             "@phpcs",
-            "@phpstan",
-            "@tests"
-        ],
-        "ci": [
-            "@composer validate --no-check-publish --no-check-all",
-            "@build"
+            "@phpstan"
         ]
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="./tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <testsuite name="Main Test Suite">
-    <directory>./tests</directory>
-  </testsuite>
+  <testsuites>
+    <testsuite name="aws">
+      <file>./tests/S3BackupTest.php</file>
+    </testsuite>
+    <testsuite name="azure">
+      <file>./tests/AbsBackupTest.php</file>
+    </testsuite>
+    <testsuite name="gcp">
+      <file>./tests/GcsBackupTest.php</file>
+      <file>./tests/FileClient/GcsFileClientTest.php</file>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/AbsBackupTest.php
+++ b/tests/AbsBackupTest.php
@@ -498,7 +498,7 @@ class AbsBackupTest extends TestCase
     {
         $bucketId = $this->sapiClient->createBucket('main', Client::STAGE_IN);
 
-        $this->sapiClient->shareBucket($bucketId, ['sharing' => 'organization']);
+        $this->sapiClient->shareOrganizationBucket($bucketId);
 
         $this->sapiClient->createTableAsync(
             'in.c-main',

--- a/tests/GcsBackupTest.php
+++ b/tests/GcsBackupTest.php
@@ -482,9 +482,9 @@ class GcsBackupTest extends TestCase
     {
         $bucketId = $this->sapiClient->createBucket('main', Client::STAGE_IN);
 
-        $this->sapiClient->shareBucket($bucketId, ['sharing' => 'organization']);
+        $this->sapiClient->shareOrganizationBucket($bucketId);
 
-        $this->sapiClient->createTable('in.c-main', 'sample', new CsvFile(__DIR__ . '/data/sample.csv'));
+        $this->sapiClient->createTableAsync('in.c-main', 'sample', new CsvFile(__DIR__ . '/data/sample.csv'));
 
         $token = $this->sapiClient->verifyToken();
         $projectId = $token['owner']['id'];

--- a/tests/S3BackupTest.php
+++ b/tests/S3BackupTest.php
@@ -519,9 +519,9 @@ class S3BackupTest extends TestCase
     {
         $bucketId = $this->sapiClient->createBucket('main', Client::STAGE_IN);
 
-        $this->sapiClient->shareBucket($bucketId, ['sharing' => 'organization']);
+        $this->sapiClient->shareOrganizationBucket($bucketId);
 
-        $this->sapiClient->createTable('in.c-main', 'sample', new CsvFile(__DIR__ . '/data/sample.csv'));
+        $this->sapiClient->createTableAsync('in.c-main', 'sample', new CsvFile(__DIR__ . '/data/sample.csv'));
 
         $token = $this->sapiClient->verifyToken();
         $projectId = $token['owner']['id'];


### PR DESCRIPTION
- Split tests into separate composer scripts for each cloud platform (AWS/Azure/GCP) - Added matrix strategy in GitHub Actions to run tests in parallel - Added concurrency settings to prevent duplicate runs - Cleaned up unused composer scripts - Ensured sequential job execution (build -> static analysis -> tests)