### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# php-kbc-project-backup – AI Development Context
+
+## What this repository does
+
+Low-level PHP library for backing up a Keboola project to cloud storage. Used by `app-project-backup` as its backup engine.
+
+## Documentation
+
+- **`docs/overview.md`** – public methods, what is backed up, backup structure in storage, what is skipped
+- **`docs/how-it-works.md`** – step-by-step backup flow (backupTable flow, FileClient selection, putToStorage per backend)
+
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**For AWS S3 tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_AWS_STORAGE_API_URL` | URL of the Keboola project on AWS stack |
+| `TEST_AWS_STORAGE_API_TOKEN` | Storage token of the project on AWS stack |
+| `TEST_AWS_ACCESS_KEY_ID` | AWS Access Key ID |
+| `TEST_AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key |
+| `TEST_AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `TEST_AWS_S3_BUCKET` | S3 bucket name for test backups |
+
+**For Azure ABS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_AZURE_STORAGE_API_URL` | URL of the Keboola project on Azure stack |
+| `TEST_AZURE_STORAGE_API_TOKEN` | Storage token of the project on Azure stack |
+| `TEST_AZURE_ACCOUNT_NAME` | Azure storage account name |
+| `TEST_AZURE_ACCOUNT_KEY` | Azure storage key |
+| `TEST_AZURE_CONTAINER_NAME` | Azure Blob Storage container name |
+
+**For GCS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_GCP_STORAGE_API_URL` | URL of the Keboola project on GCP stack |
+| `TEST_GCP_STORAGE_API_TOKEN` | Storage token of the project on GCP stack |
+| `TEST_GCP_BUCKET` | GCS bucket name for test backups |
+| `TEST_GCP_SERVICE_ACCOUNT` | JSON service account key (full JSON as string) |
+
+> Check that the `.env` file exists in the repo root. If not, create it based on the list above.
+
+## Development commands
+
+Service name in `docker-compose.yml` is `tests`. There is no `composer tests` script – tests are run per-backend.
+
+```bash
+docker compose run --rm tests composer phpcs
+docker compose run --rm tests composer phpstan
+docker compose run --rm tests composer test-aws             # S3 integration tests
+docker compose run --rm tests composer test-azure           # ABS integration tests
+docker compose run --rm tests composer test-gcp             # GCS integration tests
+docker compose run --rm tests composer static-analysis      # validate + phplint + phpcs + phpstan
+```
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/Backup.php` | Abstract class – all backup logic |
+| `src/S3Backup.php` | AWS S3 implementation |
+| `src/AbsBackup.php` | Azure Blob Storage implementation |
+| `src/GcsBackup.php` | Google Cloud Storage implementation |
+| `src/FileClient/` | Clients for downloading table files |
+| `src/NotificationClient.php` | Keboola Notification API communication |
+
+## Architecture
+
+Abstract class `Backup` + concrete implementations for each backend (S3Backup, AbsBackup, GcsBackup). Separate file clients for accessing storage files.
+
+## Coding standards
+
+- PHP 8.x with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12)
+
+## Related repositories
+
+- Used in: `app-project-backup`
+- Paired with: `php-kbc-project-restore`

--- a/composer.json
+++ b/composer.json
@@ -54,14 +54,14 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "cweagans/composer-patches": true
-        }
-    },
-    "audit": {
-        "ignore": {
-            "PKSA-y2cr-5h3j-g3ys": "firebase/php-jwt is a transitive dependency via google/auth, advisory not exploitable in this context",
-            "PKSA-2kqm-ps5x-s4f5": "firebase/php-jwt is a transitive dependency via google/auth, advisory not exploitable in this context"
         },
-        "block-insecure": false
+        "audit": {
+            "ignore": [
+                "PKSA-y2cr-5h3j-g3ys",
+                "PKSA-2kqm-ps5x-s4f5"
+            ],
+            "block-insecure": false
+        }
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,12 @@
             "cweagans/composer-patches": true
         }
     },
+    "audit": {
+        "ignore": [
+            "PKSA-y2cr-5h3j-g3ys",
+            "PKSA-2kqm-ps5x-s4f5"
+        ]
+    },
     "extra": {
         "patches": {
             "microsoft/azure-storage-common": [

--- a/composer.json
+++ b/composer.json
@@ -57,10 +57,11 @@
         }
     },
     "audit": {
-        "ignore": [
-            "PKSA-y2cr-5h3j-g3ys",
-            "PKSA-2kqm-ps5x-s4f5"
-        ]
+        "ignore": {
+            "PKSA-y2cr-5h3j-g3ys": "firebase/php-jwt is a transitive dependency via google/auth, advisory not exploitable in this context",
+            "PKSA-2kqm-ps5x-s4f5": "firebase/php-jwt is a transitive dependency via google/auth, advisory not exploitable in this context"
+        },
+        "block-insecure": false
     },
     "extra": {
         "patches": {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,141 @@
+# php-kbc-project-backup – how the backup works
+
+## Initializing the Backup class
+
+```php
+new S3Backup($sapiClient, $logger)  // or AbsBackup / GcsBackup
+```
+
+`Backup::__construct()` constructor:
+1. Stores `sapiClient`
+2. Fetches branch list (`DevBranches::listBranches()`)
+3. Finds the default branch (`isDefault === true`)
+4. Creates `BranchAwareClient` for operations on the default branch
+
+## Backup flow
+
+```
+backupProjectMetadata()
+  └─ DevBranchesMetadata::listBranchMetadata()
+  └─ putToStorage('defaultBranchMetadata.json', json)
+
+backupTablesMetadata()
+  ├─ listBuckets() → putToStorage('buckets.json', json)
+  └─ listTables()  → putToStorage('tables.json', json)
+
+backupTable($tableId)
+  └─ see section below
+
+backupConfigs($includeVersions)
+  └─ see section below
+
+backupTriggers()
+  └─ listTriggers() → putToStorage('triggers.json', json)
+
+backupNotifications()
+  └─ filters only default branch notifications
+  └─ putToStorage('notifications.json', json)
+
+backupPermanentFiles()
+  └─ listFiles(isPermanent: true) → forEach: putToStorage('files/<fileId>', stream)
+  └─ putToStorage('permanentFiles.json', json)
+
+backupSignedUrls()   [GcsBackup only]
+  └─ putToStorage('signedUrls.json', json)
+```
+
+## backupTable – detail
+
+```
+getTableFileInfo($tableId):
+  1. getTable($tableId)            – table metadata
+  2. Skip checks:
+     - stage === 'sys'             → SkipTableException (warning, continues)
+     - hasExternalSchema           → SkipTableException
+     - sourceBucket (DataCatalog)  → SkipTableException
+     - isAlias                     → SkipTableException
+  3. exportTableAsync($tableId, gzip: true)  – SAPI async export
+  4. getFile($fileId, federationToken: true) → fileInfo with cloud credentials
+
+getFileClient($fileInfo):
+  - fileInfo.credentials present       → S3FileClient
+  - fileInfo.absCredentials present    → AbsFileClient
+  - fileInfo.provider === 'gcp'        → GcsFileClient
+
+if isSliced:
+  GET manifest URL → foreach entry → putToStorage(table.part_N.csv.gz, chunk)
+else:
+  putToStorage(stage/c-bucket/table.csv.gz, fileClient.getFileContent())
+```
+
+### Why federationToken
+
+`getFile(federationToken: true)` returns temporary cloud credentials (AWS STS token, ABS SAS token, or GCS access token). FileClient then accesses cloud storage directly without going through SAPI. Without federationToken, every byte would have to pass through the SAPI HTTP API, which is significantly slower for large tables.
+
+### Paths in storage
+
+```
+stage/c-bucketName/tableName.csv.gz          (non-sliced)
+stage/c-bucketName/tableName.part_0.csv.gz   (sliced, part 0)
+stage/c-bucketName/tableName.part_1.csv.gz   (sliced, part 1)
+...
+```
+
+Dots in `tableId` (e.g. `in.c-bucket.table`) are replaced with slashes:
+```php
+str_replace('.', '/', $tableId)  →  in/c-bucket/table
+```
+
+## backupConfigs – detail
+
+```
+Load all components with configurations (apiGet 'components?include=configuration')
+
+foreach component:
+  foreach configuration:
+    putToStorage('configurations/<componentId>/<configId>.json', data + rows + state)
+
+    if includeVersions:
+      paginated (CONFIGURATION_PAGING_LIMIT = 2 per page):
+        putToStorage(version data)
+
+    putToStorage('configurations/<componentId>/<configId>.json.metadata', metadata)
+```
+
+`CONFIGURATION_PAGING_LIMIT = 2` – intentionally low limit, but applies **only to configuration versions**, not to loading the configurations themselves (those are always fetched in a single call).
+
+## putToStorage – implementation per backend
+
+Abstract method, each backend implements it differently:
+
+| Backend | Method | Parameters |
+|---------|--------|-----------|
+| `S3Backup` | `S3Client::putObject()` | Bucket, Key (= path), Body (= content) |
+| `AbsBackup` | `BlobRestProxy::createBlockBlob()` | container, blobName, content |
+| `GcsBackup` | `Bucket->object($name)->upload($content)` | GCS bucket object upload |
+
+Content (`$content`) is either `string` (JSON files) or `resource` (binary file streams).
+
+## FileClient – client selection
+
+```
+IFileClient
+  ├─ S3FileClient   – getFileContent() via S3Client::getObject()
+  ├─ AbsFileClient  – getFileContent() via BlobRestProxy::getBlob()
+  └─ GcsFileClient  – getFileContent() via StorageClient
+```
+
+Client selection depends on fields in `fileInfo` returned by SAPI:
+- `credentials` field → S3FileClient (AWS)
+- `absCredentials` field → AbsFileClient (Azure)
+- `provider === 'gcp'` → GcsFileClient (Google Cloud)
+
+## What is skipped and why
+
+| Condition | Reason for skipping |
+|----------|-----------------|
+| `stage === 'sys'` | Sys buckets are system-level, do not belong to the user |
+| `isAlias === true` | Alias has no own data, references another bucket |
+| `hasExternalSchema` | Data is managed externally (Snowflake external table) |
+| `sourceBucket` not null | Data Catalog table – data is in the source bucket |
+| Notifications outside default branch | Branch notifications are not migrated |

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -60,7 +60,7 @@ getTableFileInfo($tableId):
 getFileClient($fileInfo):
   - fileInfo.credentials present       → S3FileClient
   - fileInfo.absCredentials present    → AbsFileClient
-  - fileInfo.provider === 'gcp'        → GcsFileClient
+  - fileInfo.gcsCredentials present    → GcsFileClient
 
 if isSliced:
   GET manifest URL → foreach entry → putToStorage(table.part_N.csv.gz, chunk)
@@ -128,7 +128,7 @@ IFileClient
 Client selection depends on fields in `fileInfo` returned by SAPI:
 - `credentials` field → S3FileClient (AWS)
 - `absCredentials` field → AbsFileClient (Azure)
-- `provider === 'gcp'` → GcsFileClient (Google Cloud)
+- `gcsCredentials` field → GcsFileClient (Google Cloud)
 
 ## What is skipped and why
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,7 +37,7 @@ FileClient (interface)
 | `backupTriggers()` | `triggers.json` |
 | `backupNotifications()` | `notifications.json` |
 | `backupPermanentFiles()` | `files/<fileId>` + `permanentFiles.json` |
-| `backupSignedUrls()` | `signedUrls.json` (GCS without user credentials only) |
+| `backupSignedUrls()` | `signedUrls.json` (GCS backend only; populated with signed URLs only when `generateSignedUrls` is enabled) |
 
 ## What is skipped
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,103 @@
+# php-kbc-project-backup – overview
+
+## What the library does
+
+Low-level PHP library for backing up a Keboola project to cloud storage. Contains no Keboola-specific boilerplate – it is pure backup logic that can be used from any PHP code.
+
+Used by `app-project-backup` as its backup engine.
+
+## Architecture
+
+Abstract class `Backup` contains all logic. Concrete storage backends extend it:
+
+```
+Backup (abstract)
+  ├─ S3Backup      – AWS S3
+  ├─ AbsBackup     – Azure Blob Storage
+  └─ GcsBackup     – Google Cloud Storage
+```
+
+Separate file clients exist for direct access to table files in storage (via federated credentials):
+
+```
+FileClient (interface)
+  ├─ S3FileClient
+  ├─ AbsFileClient
+  └─ GcsFileClient
+```
+
+## Public methods
+
+| Method | What it saves to storage |
+|---|---|
+| `backupProjectMetadata()` | `defaultBranchMetadata.json` |
+| `backupTablesMetadata()` | `buckets.json`, `tables.json` |
+| `backupTable(string $tableId)` | gzip CSV data for one table |
+| `backupConfigs(bool $includeVersions)` | `configurations/<componentId>/<configId>.json` |
+| `backupTriggers()` | `triggers.json` |
+| `backupNotifications()` | `notifications.json` |
+| `backupPermanentFiles()` | `files/<fileId>` + `permanentFiles.json` |
+| `backupSignedUrls()` | `signedUrls.json` (GCS without user credentials only) |
+
+## What is skipped
+
+- Sys bucket tables (`stage === 'sys'`)
+- Alias tables (`isAlias === true`)
+- External schema tables (`hasExternalSchema === true`)
+- Data Catalog tables (bucket has `sourceBucket`)
+- Notifications not belonging to the default branch
+
+## Backup structure in storage
+
+```
+<backup_path>/
+  ├─ defaultBranchMetadata.json
+  ├─ buckets.json
+  ├─ tables.json
+  ├─ configurations.json         (index of all components with configurations)
+  ├─ triggers.json
+  ├─ notifications.json
+  ├─ permanentFiles.json
+  ├─ signedUrls.json             (GCS backend only)
+  ├─ configurations/
+  │    └─ <componentId>/
+  │         ├─ <configId>.json
+  │         └─ <configId>.json.metadata
+  ├─ in/
+  │    └─ c-<bucketName>/
+  │         ├─ <tableName>.csv.gz          (non-sliced)
+  │         └─ <tableName>.part_0.csv.gz   (sliced)
+  └─ files/
+       └─ <fileId>
+```
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Backup.php` | Abstract class – all backup logic |
+| `src/S3Backup.php` | AWS S3 implementation |
+| `src/AbsBackup.php` | Azure Blob Storage implementation |
+| `src/GcsBackup.php` | Google Cloud Storage implementation |
+| `src/FileClient/` | Clients for direct table file downloads from storage |
+| `src/NotificationClient.php` | Keboola Notification API communication |
+
+## Development and testing
+
+Service name in `docker-compose.yml` is `tests`. There is no `composer tests` script – tests are split per-backend.
+
+```bash
+docker compose run --rm tests composer phpcs
+docker compose run --rm tests composer phpstan
+docker compose run --rm tests composer test-aws           # S3 tests
+docker compose run --rm tests composer test-azure         # ABS tests
+docker compose run --rm tests composer test-gcp           # GCS tests
+docker compose run --rm tests composer static-analysis    # validate + phplint + phpcs + phpstan
+```
+
+Integration tests require live Keboola credentials (a project on each of the three cloud stacks + credentials for the respective storage).
+
+## Related repositories
+
+- Used in: `app-project-backup`
+- Paired with: `php-kbc-project-restore`


### PR DESCRIPTION
Add CLAUDE.md with AI development context, required environment variables, key files and development commands. Add docs/ folder with overview and how-it-works documentation covering the public Backup API, backup structure in storage, federation tokens, FileClient selection logic and per-backend putToStorage implementations.